### PR TITLE
Persist limit buffers

### DIFF
--- a/src/rx-query.ts
+++ b/src/rx-query.ts
@@ -280,12 +280,6 @@ export class RxQueryBase<
 
 
         if (this.op === 'count') {
-            // if we have a persisted query cache result, use the result
-            if (this._persistentQueryCacheResult) {
-                // TODO: correct this number, but how?
-                return Number(this._persistentQueryCacheResult);
-            }
-
             const preparedQuery = this.getPreparedQuery();
             const result = await this.collection.storageInstance.count(preparedQuery);
             if (result.mode === 'slow' && !this.collection.database.allowSlowCount) {

--- a/src/rx-query.ts
+++ b/src/rx-query.ts
@@ -535,7 +535,6 @@ export class RxQueryBase<
             // no cache backend provided, do nothing
             return;
         }
-
         if (this._persistentQueryCacheResult) {
             // we already restored the cache once, no need to run twice
             return;
@@ -553,24 +552,26 @@ export class RxQueryBase<
             console.log(`no persistent query cache found in the backend, returning early ${this.toString()}`);
             return;
         }
+
         // eslint-disable-next-line no-console
         console.time(`Restoring persistent querycache ${this.toString()}`);
 
+        const primaryPath = this.collection.schema.primaryPath;
         const results = await Promise.all([
             this._persistentQueryCacheBackend.getItem(`qc:${persistentQueryId}:lwt`),
             this._persistentQueryCacheBackend.getItem(`qc:${persistentQueryId}:lb`),
         ]);
-        const [lwt, limitBufferIds] = [results[0] as string | null, results[1] as string[] | null];
+        const lwt = results[0] as string | null;
+        const limitBufferIds = new Set<string>(results[1] ?? []);
 
-        const primaryPath = this.collection.schema.primaryPath;
+        if (!lwt) {
+            return;
+        }
 
-        this._persistentQueryCacheResult = value ?? undefined;
-        this._persistentQueryCacheResultLwt = lwt ?? undefined;
+        this._persistentQueryCacheResult = value;
+        this._persistentQueryCacheResultLwt = lwt;
 
         const persistedQueryCacheIds = new Set(this._persistentQueryCacheResult);
-
-        let docsData: RxDocumentData<RxDocType>[] = [];
-        const changedDocIds: Set<string> = new Set();
 
         // query all docs updated > last persisted, limit to an arbitrary 1_000_000 (10x of what we consider our largest library)
         const {documents: changedDocs} = await this.collection.storageInstance.getChangedDocumentsSince(
@@ -580,72 +581,24 @@ export class RxQueryBase<
           {id: '', lwt: Math.floor(Number(lwt)) - UPDATE_DRIFT}
         );
 
-        for (const changedDoc of changedDocs) {
-          const docWasInOldPersistedResults = persistedQueryCacheIds.has(changedDoc[primaryPath] as string);
-          const docMatchesNow = this.doesDocumentDataMatch(changedDoc);
+        const changedDocIds = new Set<string>(changedDocs.map((d) => d[primaryPath] as string));
 
-          if (docWasInOldPersistedResults && !docMatchesNow && this.mangoQuery.limit && !limitBufferIds?.length) {
-            // Unfortunately if any doc was removed from the results since the last result,
-            // there is no way for us to be sure our calculated results are correct.
-            // So we should simply give up and re-exec the query.
-            this._persistentQueryCacheResult = value ?? undefined;
-            this._persistentQueryCacheResultLwt = lwt ?? undefined;
-            return;
-          }
+        const docIdsWeNeedToFetch = [...persistedQueryCacheIds, ...limitBufferIds].filter((id) => !changedDocIds.has(id));
 
-          if (docWasInOldPersistedResults) {
-            /*
-            * no need to fetch again, we already got the doc from the list of changed docs, and therefore we filter
-            * out docs that are no longer matching the query.
-            */
-            persistedQueryCacheIds.delete(changedDoc[primaryPath] as string);
-          }
+        // We use _queryCollectionByIds to fetch the remaining docs we need efficiently, pulling
+        // from query cache if we can (and the storageInstance by ids if we can't):
+        const otherPotentialMatchingDocs: RxDocumentData<RxDocType>[] = [];
+        await _queryCollectionByIds(this as any, otherPotentialMatchingDocs, docIdsWeNeedToFetch);
 
-          // ignore deleted docs or docs that do not match the query
-          if (!docMatchesNow) {
-            continue;
-          }
-
-          // add to document cache
-          this.collection._docCache.getCachedRxDocument(changedDoc);
-
-          // add to docs
-          docsData.push(changedDoc);
-          changedDocIds.add(changedDoc[primaryPath] as string);
-        }
-
-        // Get the rest of the doc ids we need to consider:
-        const moreDocIdsToConsider = new Set(Array.from(persistedQueryCacheIds).concat(limitBufferIds ?? []));
-
-        const nonRestoredDocIds: string[] = [];
-        for (const docId of moreDocIdsToConsider) {
-            if (changedDocIds.has(docId)) {
-                // we already fetched this doc because it changed, don't get it again
-                continue;
-            }
-
-            // first try to fill from docCache
-            const docData = this.collection._docCache.getLatestDocumentDataIfExists(docId);
-            if (docData && this.doesDocumentDataMatch(docData)) {
-              docsData.push(docData);
-            }
-
-            if (!docData) {
-              nonRestoredDocIds.push(docId);
+        // Now that we have all potential documents, we just filter (in-memory) the ones that still match our query:
+        let docsData: RxDocumentData<RxDocType>[] = [];
+        for (const doc of changedDocs.concat(otherPotentialMatchingDocs)) {
+            if (this.doesDocumentDataMatch(doc)) {
+                docsData.push(doc);
             }
         }
 
-        // otherwise get from storage
-        if (nonRestoredDocIds.length > 0) {
-            const docsMap = await this.collection.storageInstance.findDocumentsById(nonRestoredDocIds, false);
-            Object.values(docsMap).forEach(docData => {
-                if (this.doesDocumentDataMatch(docData)) {
-                    this.collection._docCache.getCachedRxDocument(docData);
-                    docsData.push(docData);
-                }
-            });
-        }
-
+        // Sort the documents by the query's sort field:
         const normalizedMangoQuery = normalizeMangoQuery<RxDocType>(
           this.collection.schema.jsonSchema,
           this.mangoQuery
@@ -654,25 +607,36 @@ export class RxQueryBase<
         const limit = normalizedMangoQuery.limit ? normalizedMangoQuery.limit : Infinity;
         docsData = docsData.sort(sortComparator);
 
+        // We know for sure that all persisted and limit buffer ids (and changed docs before them) are in the correct
+        // result set. And we can't be sure about any past that point. So cut it off there:
+        const lastValidIndex = docsData.findLastIndex((d) => limitBufferIds.has(d[primaryPath] as string) || persistedQueryCacheIds.has(d[primaryPath] as string));
+        docsData = docsData.slice(0, lastValidIndex + 1);
+
+        // Now this is the trickiest part.
+        // If we somehow have fewer docs than the limit of our query
+        // (and this wasn't the case because before persistence)
+        // then there is no way for us to know the correct results, and we re-exec:
+        const unchangedItemsMayNowBeInResults = (
+            this.mangoQuery.limit &&
+            docsData.length < this.mangoQuery.limit &&
+            persistedQueryCacheIds.size >= this.mangoQuery.limit
+        );
+        if (unchangedItemsMayNowBeInResults) {
+            this._persistentQueryCacheResult = undefined;
+            this._persistentQueryCacheResultLwt = undefined;
+            return;
+        }
+
+        // Our finalResults are the actual results of this query, and pastLimitItems are any remaining matching
+        // documents we have left over (past the limit).
         const pastLimitItems = docsData.slice(limit);
         const finalResults = docsData.slice(0, limit);
 
-        // If we had a limit buffer before, and now we don't... it means the limit buffer was exhausted.
-        // To be confident we're not missing anything, we need to re-exec the query:
-        if (limitBufferIds?.length && pastLimitItems.length === 0) {
-            this._persistentQueryCacheResult = value ?? undefined;
-            this._persistentQueryCacheResultLwt = lwt ?? undefined;
-            return;
-        }
         // If there are still items past the first LIMIT items, try to restore the limit buffer with them:
-        if (limitBufferIds?.length && pastLimitItems.length > 0) {
-            const lastLimitBufferIndex = pastLimitItems.findLastIndex((d) => limitBufferIds.includes(d[primaryPath] as string));
-            if (lastLimitBufferIndex !== -1){
-                // If the limit buffer still has room, simply restore it:
-                this._limitBufferResults = pastLimitItems.slice(0, Math.max(lastLimitBufferIndex + 1, this._limitBufferSize ?? 0));
-            } else {
-                this._limitBufferResults = [];
-            }
+        if (limitBufferIds.size && pastLimitItems.length > 0) {
+            this._limitBufferResults = pastLimitItems;
+        } else {
+            this._limitBufferResults = [];
         }
 
         // get query into the correct state
@@ -682,7 +646,6 @@ export class RxQueryBase<
 
         // eslint-disable-next-line no-console
         console.timeEnd(`Restoring persistent querycache ${this.toString()}`);
-
     }
 }
 

--- a/src/rx-query.ts
+++ b/src/rx-query.ts
@@ -809,16 +809,6 @@ async function __ensureEqual<RxDocType>(rxQuery: RxQueryBase<RxDocType>): Promis
                     // we got the new results, we do not have to re-execute, mustReExec stays false
                     ret = true; // true because results changed
                     rxQuery._setResultData(eventReduceResult.newResults as any);
-
-                    /*
-                     * We usually want to persist the cache every time there is an update to the query to guarantee
-                     * correctness. Cache persistence has some "cost", and we therefore try to optimize the number of
-                     * writes.
-                     * So, if any item in the result set was removed, we re-persist the query.
-                    */
-                    if (rxQuery.mangoQuery.limit && eventReduceResult.limitResultsRemoved) {
-                      await updatePersistentQueryCache(rxQuery);
-                    }
                 }
             }
         }

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,6 +1,8 @@
 import './unit/init.test';
 import './unit/util.test';
 
+import './unit/rx-query.test';
+
 
 /**
  * Helpers that
@@ -36,7 +38,6 @@ import './unit/validate.test';
 import './unit/attachments.test';
 import './unit/attachments-compression.test';
 import './unit/encryption.test';
-import './unit/rx-query.test';
 import './unit/cross-instance.test';
 import './unit/local-documents.test';
 import './unit/change-event-buffer.test';

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,8 +1,6 @@
 import './unit/init.test';
 import './unit/util.test';
 
-import './unit/rx-query.test';
-
 
 /**
  * Helpers that
@@ -38,6 +36,7 @@ import './unit/validate.test';
 import './unit/attachments.test';
 import './unit/attachments-compression.test';
 import './unit/encryption.test';
+import './unit/rx-query.test';
 import './unit/cross-instance.test';
 import './unit/local-documents.test';
 import './unit/change-event-buffer.test';

--- a/test/unit/rx-query.test.ts
+++ b/test/unit/rx-query.test.ts
@@ -1831,7 +1831,7 @@ describe('rx-query.test.ts', () => {
             collection.database.destroy();
         });
 
-        describe.only('persisting queries with limit buffers', () => {
+        describe('persisting queries with limit buffers', () => {
             async function setUpLimitBufferSituation() {
                 const {collection} = await setUpPersistentQueryCacheCollection();
                 await collection.bulkInsert([

--- a/test/unit/rx-query.test.ts
+++ b/test/unit/rx-query.test.ts
@@ -1596,7 +1596,7 @@ describe('rx-query.test.ts', () => {
 
             const query = collection.find({ limit: 1 });
             const cache = new Cache();
-            query.enablePersistentQueryCache(cache);
+            query.enableLimitBuffer(5).enablePersistentQueryCache(cache);
 
             const human1 = schemaObjects.human();
             const human2 = schemaObjects.human();
@@ -1604,7 +1604,7 @@ describe('rx-query.test.ts', () => {
             await collection.bulkInsert([human1, human2]);
             await query.exec();
 
-            assert.strictEqual(cache.size, 2);
+            assert.strictEqual(cache.size, 3);
 
             collection.database.destroy();
         });
@@ -1624,7 +1624,7 @@ describe('rx-query.test.ts', () => {
             const cache = new Cache();
             await cache.setItem(`qc:${queryId}`, [human1.passportId, human2.passportId]);
             await cache.setItem(`qc:${queryId}:lwt`, `${now()}`);
-            query.enablePersistentQueryCache(cache);
+            query.enableLimitBuffer(5).enablePersistentQueryCache(cache);
 
             // execute query
             const result = await query.exec();
@@ -1650,7 +1650,7 @@ describe('rx-query.test.ts', () => {
             const cache = new Cache();
             await cache.setItem(`qc:${queryId}`, [human1.passportId]);
             await cache.setItem(`qc:${queryId}:lwt`, `${now()}`);
-            query1.enablePersistentQueryCache(cache);
+            query1.enableLimitBuffer(5).enablePersistentQueryCache(cache);
 
             // execute query
             const result1 = await query1.exec();
@@ -1665,7 +1665,7 @@ describe('rx-query.test.ts', () => {
             clearQueryCache(collection);
 
             const query2 = collection.find({ selector: { age: human1Age }});
-            query2.enablePersistentQueryCache(cache);
+            query2.enableLimitBuffer(5).enablePersistentQueryCache(cache);
 
             const result2 = await query2.exec();
 
@@ -1691,7 +1691,7 @@ describe('rx-query.test.ts', () => {
             const cache = new Cache();
             await cache.setItem(`qc:${queryId}`, [human1.passportId, human2.passportId]);
             await cache.setItem(`qc:${queryId}:lwt`, `${now()}`);
-            query.enablePersistentQueryCache(cache);
+            query.enableLimitBuffer(5).enablePersistentQueryCache(cache);
 
             const result1 = await query.exec();
 
@@ -1728,7 +1728,7 @@ describe('rx-query.test.ts', () => {
             clearQueryCache(collection);
 
             const query2 = collection.find({ limit: 2, sort: [{age: 'asc'}] });
-            query2.enablePersistentQueryCache(cache);
+            query2.enableLimitBuffer(5).enablePersistentQueryCache(cache);
 
             const result2 = await query2.exec();
 
@@ -1762,7 +1762,7 @@ describe('rx-query.test.ts', () => {
             clearQueryCache(collection);
 
             const query2 = collection.find({ limit: 2, sort: [{age: 'asc'}] });
-            query2.enablePersistentQueryCache(cache);
+            query2.enableLimitBuffer(5).enablePersistentQueryCache(cache);
 
             assert.strictEqual(cache.getItem(`qc:${queryId}`).length, 3);
 
@@ -1785,7 +1785,7 @@ describe('rx-query.test.ts', () => {
             // fill cache
             const cache = new Cache();
             const query1 = collection.find({limit: 1});
-            query1.enablePersistentQueryCache(cache);
+            query1.enableLimitBuffer(5).enablePersistentQueryCache(cache);
             const queryId = query1.persistentQueryId();
 
             const result1 = await query1.exec();
@@ -1799,7 +1799,7 @@ describe('rx-query.test.ts', () => {
             await cache.setItem(`qc:${queryId}:lwt`, `${lwt}`);
 
             const query2 = collection.find({limit: 1});
-            query2.enablePersistentQueryCache(cache);
+            query2.enableLimitBuffer(5).enablePersistentQueryCache(cache);
             await query2._persistentQueryCacheLoaded;
 
             await result1[0].remove();
@@ -1821,7 +1821,7 @@ describe('rx-query.test.ts', () => {
             const query = collection.find({ limit: 3 });
 
             const cache = new Cache();
-            query.enablePersistentQueryCache(cache);
+            query.enableLimitBuffer(5).enablePersistentQueryCache(cache);
 
             const result = await query.exec();
 
@@ -1831,49 +1831,173 @@ describe('rx-query.test.ts', () => {
             collection.database.destroy();
         });
 
-        it('gives correct limit results when items were removed', async () => {
-            const {collection} = await setUpPersistentQueryCacheCollection();
-            const human1 = schemaObjects.human('1', 30);
-            const human2 = schemaObjects.human('2', 40);
-            const human3 = schemaObjects.human('3', 50);
-            await collection.bulkInsert([human1, human2, human3]);
+        describe.only('persisting queries with limit buffers', () => {
+            async function setUpLimitBufferSituation() {
+                const {collection} = await setUpPersistentQueryCacheCollection();
+                await collection.bulkInsert([
+                    schemaObjects.human('1', 30),
+                    schemaObjects.human('2', 40),
+                    schemaObjects.human('3', 50),
+                    schemaObjects.human('4', 60),
+                    schemaObjects.human('5', 70),
+                ]);
 
-            // wait 1 second so that not all docs are included in lwt
-            await new Promise((resolve) => {
-                setTimeout(resolve, 1000);
-                return;
+                // wait 1 second so that not all docs are included in lwt
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 1000);
+                });
+
+                // Cache a limited query:
+                const query = collection.find({ limit: 2, sort: [{age: 'asc'}], selector: { age: { $gt: 10 } } });
+                const cache = new Cache();
+
+                return { query, cache, collection };
+            }
+
+            // This is how it should operate when we don't persist limit buffers:
+            it('limit buffer not enabled, still gives correct results through re-execution', async () => {
+                const { collection, query, cache} = await setUpLimitBufferSituation();
+
+                // persist with no limit buffer enabled
+                await query.enablePersistentQueryCache(cache);
+                const originalResults = await query.exec();
+                assert.deepStrictEqual(originalResults.map(h => h.passportId), ['1', '2']);
+
+                // Now, get into a state where that query is no longer in memory (eg new tab)
+                // (but, the query should still be persisted on disk)
+                uncacheRxQuery(collection._queryCache, query);
+                assert.strictEqual(cache.size, 2);
+
+                // while the query is not in memory, remove one of the items from the query results
+                await collection.find({selector: { passportId: '1'}}).update({
+                    $set: { age: 1 }
+                });
+
+                // now when we create the query again, it has no way of knowing how to fill the missing item
+                const queryAgain = collection.find(query.mangoQuery);
+                assert.strictEqual(queryAgain._execOverDatabaseCount, 0);
+
+                await queryAgain.enablePersistentQueryCache(cache);
+                const updatedResults = await queryAgain.exec();
+
+                // We must re-exec the query to make it correct.
+                assert.strictEqual(queryAgain._execOverDatabaseCount, 1);
+                assert.deepStrictEqual(updatedResults.map(h => h.passportId), ['2', '3']);
+                collection.database.destroy();
             });
 
-            // Cache a limited query:
-            const query = collection.find({ limit: 2, sort: [{age: 'asc'}], selector: { age: { $gt: 10 } } });
-            const cache = new Cache();
-            await query.enablePersistentQueryCache(cache);
-            const originalResults = await query.exec();
-            assert.deepStrictEqual(originalResults.map(h => h.passportId), ['1', '2']);
+            it('limit buffer enabled, restores changed results correctly with no re-exec', async () => {
+                const { collection, query, cache} = await setUpLimitBufferSituation();
 
-            // Now, get into a state where that query is no longer in memory (eg new tab)
-            // (but, the query should still be persisted on disk)
-            uncacheRxQuery(collection._queryCache, query);
-            assert.strictEqual(cache.size, 2);
+                // Persist WITH the limit buffer enabled
+                query.enableLimitBuffer(5).enablePersistentQueryCache(cache);
 
-            // while the query is not in memory, remove one of the items from the query results
-            await collection.find({selector: { passportId: '1'}}).update({
-                $set: {
-                    age: 1,
-                }
+                const originalResults = await query.exec();
+                assert.deepStrictEqual(originalResults.map(h => h.passportId), ['1', '2']);
+                assert.strictEqual(query._limitBufferResults?.length, 3);
+
+                uncacheRxQuery(collection._queryCache, query);
+                assert.strictEqual(cache.size, 3);
+
+                // remove one of the items from the query results
+                await collection.find({ selector: { passportId: '1' } }).update({
+                    $set: { age: 1 }
+                });
+
+                // now when we create the query again, it will fill in the missing element from the limit buffer
+                const queryAgain = collection.find(query.mangoQuery);
+                queryAgain.enableLimitBuffer(5).enablePersistentQueryCache(cache);
+
+                const updatedResults = await queryAgain.exec();
+
+                // The query should use the limit buffer to restore the results, and not need to re-exec the query
+                assert.strictEqual(queryAgain._execOverDatabaseCount, 0);
+                assert.deepStrictEqual(updatedResults.map(h => h.passportId), ['2', '3']);
+
+                // There should now only be 2 items left in the limit buffer, it used the first one up to fill the results
+                assert.strictEqual(queryAgain._limitBufferResults?.length, 2);
+
+                collection.database.destroy();
             });
 
-            // now when we create the query again, it has no way of knowing how to fill the missing item
-            const queryAgain = collection.find({ limit: 2, sort: [{age: 'asc'}], selector: { age: { $gt: 10 } } });
-            assert.strictEqual(queryAgain._execOverDatabaseCount, 0);
+            it('limit buffer enabled, but gets exhausted', async () => {
+                const { collection, query, cache} = await setUpLimitBufferSituation();
 
-            await queryAgain.enablePersistentQueryCache(cache);
-            const updatedResults = await queryAgain.exec();
+                // Persist WITH the limit buffer enabled, but only one doc
+                query.enableLimitBuffer(1).enablePersistentQueryCache(cache);
+                await query.exec();
+                uncacheRxQuery(collection._queryCache, query);
 
-            // We must re-exec the query to make it correct.
-            assert.strictEqual(queryAgain._execOverDatabaseCount, 1);
-            assert.deepStrictEqual(updatedResults.map(h => h.passportId), ['2', '3']);
-            collection.database.destroy();
+                // remove two of the items from the query results
+                await collection.find({ selector: { passportId: '1' } }).update({
+                    $set: { age: 1 }
+                });
+                await collection.find({ selector: { passportId: '2' } }).update({
+                    $set: { age: 1 }
+                });
+
+                // now when we create the query again, it will fill in the missing element from the limit buffer
+                // but then still need another item to hit the limit=2
+                const queryAgain = collection.find(query.mangoQuery);
+                queryAgain.enableLimitBuffer(1).enablePersistentQueryCache(cache);
+
+                const updatedResults = await queryAgain.exec();
+
+                // The query will have to still re-exec, but give the correct results
+                assert.strictEqual(queryAgain._execOverDatabaseCount, 1);
+                assert.deepStrictEqual(updatedResults.map(h => h.passportId), ['3', '4']);
+
+                // And re-fill the 1 item in limit buffer:
+                assert.strictEqual(queryAgain._limitBufferResults?.length, 1);
+                assert.strictEqual(queryAgain._limitBufferResults?.[0].passportId, '5');
+
+                collection.database.destroy();
+            });
+
+            it('limit buffer enabled, doc added and limit buffer items changed, still restores correctly', async () => {
+                const { collection, query, cache} = await setUpLimitBufferSituation();
+
+                // Persist WITH the limit buffer enabled
+                query.enableLimitBuffer(5).enablePersistentQueryCache(cache);
+
+                await query.exec();
+
+                uncacheRxQuery(collection._queryCache, query);
+
+                // Let's make 3 changes:
+                // 1. remove both of the original results
+                // 2. add in a new doc that should now be in the results
+                // 3. modify one of the items in the limit buffer to change the correct order there
+                await collection.find({ selector: { passportId: '1' } }).update({
+                    $set: { age: 1 }
+                });
+                await collection.find({ selector: { passportId: '2' } }).update({
+                    $set: { age: 1 }
+                });
+                // the new item should now be the first result, since it has the lowest age
+                await collection.bulkUpsert([
+                    schemaObjects.human('6', 20),
+                ]);
+                // change what would be the next result (passport id 3) to still match the filter, but now be last (so not in the results)
+                await collection.find({ selector: { passportId: '3' } }).update({
+                    $set: { age: 100 }
+                });
+
+                const queryAgain = collection.find(query.mangoQuery);
+                queryAgain.enableLimitBuffer(5).enablePersistentQueryCache(cache);
+                const updatedResults = await queryAgain.exec();
+
+                // The query should use the limit buffer to restore the results, and not need to re-exec the query
+                assert.strictEqual(queryAgain._execOverDatabaseCount, 0);
+
+                // But it should also correctly fill in the new document into the correct position, and also handle the sort change
+                assert.deepStrictEqual(updatedResults.map(h => h.passportId), ['6', '4']);
+
+                // The two items in limit buffer should be in the correct order:
+                assert.deepStrictEqual(queryAgain._limitBufferResults?.map((d) => d.passportId), ['5', '3']);
+
+                collection.database.destroy();
+            });
         });
     });
 });

--- a/test/unit/rx-query.test.ts
+++ b/test/unit/rx-query.test.ts
@@ -1604,7 +1604,7 @@ describe('rx-query.test.ts', () => {
             await collection.bulkInsert([human1, human2]);
             await query.exec();
 
-            assert.strictEqual(cache.size, 3);
+            assert.strictEqual(cache.size, 2);
 
             collection.database.destroy();
         });
@@ -1900,7 +1900,7 @@ describe('rx-query.test.ts', () => {
                 const originalResults = await query.exec();
                 assert.deepStrictEqual(originalResults.map(h => h.passportId), ['1', '2']);
                 assert.strictEqual(query._limitBufferResults?.length, 3);
-                assert.strictEqual(cache.size, 3);
+                assert.strictEqual(cache.size, 2);
 
                 // remove one of the items from the query results
                 await collection.find({ selector: { passportId: '1' } }).update({
@@ -1937,7 +1937,7 @@ describe('rx-query.test.ts', () => {
 
                 // uncache the query first, before changes are made
                 simulateNewSession(collection);
-                assert.strictEqual(cache.size, 3);
+                assert.strictEqual(cache.size, 2);
 
                 // remove one of the items from the query results while query is not listening in memory
                 await collection.find({ selector: { passportId: '1' } }).update({


### PR DESCRIPTION
Still needs:

- [x] Tests
- [x] Performance improvements (eg add ids to existing persisted `qc` key instead of adding new row)

Other than the above, i think this is good to go! 🤞 